### PR TITLE
fix: resolve appointments CSS syntax error and add timezone settings

### DIFF
--- a/app/views/landlord/appointments.php
+++ b/app/views/landlord/appointments.php
@@ -14,6 +14,9 @@
 </head>
 <body>
 <?php
+// Set timezone to Philippine Time
+date_default_timezone_set('Asia/Manila');
+
 // Start session and load models
 session_start();
 require_once __DIR__ . '/../../models/Appointment.php';

--- a/app/views/seeker/appointments.php
+++ b/app/views/seeker/appointments.php
@@ -1,4 +1,7 @@
 <?php
+// Set timezone to Philippine Time
+date_default_timezone_set('Asia/Manila');
+
 // Start session and load models
 session_start();
 require_once __DIR__ . '/../../models/Appointment.php';

--- a/public/assets/css/modules/appointments.module.css
+++ b/public/assets/css/modules/appointments.module.css
@@ -220,7 +220,7 @@
     }
     
     .appointment-info-grid {
-        gridtemplate-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(3, 1fr);
     }
 }
 


### PR DESCRIPTION
- Fix CSS typo in appointments.module.css: gridtemplate-columns -> grid-template-columns
- Add Asia/Manila timezone to seeker appointments.php
- Add Asia/Manila timezone to landlord appointments.php
- Ensures consistent timestamp display across all appointment views